### PR TITLE
Fix API calls to use npub instead of identifier

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -11,7 +11,7 @@ export const apiService = {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          identifier: pubkey,
+          npub: pubkey,
         }),
       });
 
@@ -48,7 +48,7 @@ export const apiService = {
           'X-Api-Key': apiKey,
         },
         body: JSON.stringify({
-          identifier: pubkey,
+          npub: pubkey,
         }),
       });
 


### PR DESCRIPTION
- Updated getUserInfo to send npub field instead of identifier
- Updated whitelistUser to send npub field instead of identifier
- Resolves 422 Unprocessable Content error from backend API